### PR TITLE
fix: 修复Star History图表链接失效

### DIFF
--- a/README-zh_cn.md
+++ b/README-zh_cn.md
@@ -123,4 +123,4 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 ## 关注数据
 
-[![Star History Chart](https://api.star-history.com/svg?repos=nashaofu/shell360&type=date&legend=top-left)](https://www.star-history.com/#nashaofu/shell360&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=nashaofu/shell360&type=date&legend=top-left)](https://star-history.dera.page/#nashaofu/shell360&type=date&legend=top-left)

--- a/README.md
+++ b/README.md
@@ -130,4 +130,4 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=nashaofu/shell360&type=date&legend=top-left)](https://www.star-history.com/#nashaofu/shell360&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=nashaofu/shell360&type=date&legend=top-left)](https://star-history.dera.page/#nashaofu/shell360&type=date&legend=top-left)


### PR DESCRIPTION
当前README中的Star History图表因GitHub stargazer API限制已失效，无法正常展示star增长数据。本PR将图表链接更新为新的数据源，保证图表稳定可用。